### PR TITLE
Add font-size and font-family

### DIFF
--- a/src/crxviewer.less
+++ b/src/crxviewer.less
@@ -12,6 +12,10 @@ html, body {
     width: 100%;
     height: 100%;
 }
+body {
+    font-family: "Segoe UI", "Lucida Grande", Tahoma, sans-serif;
+    font-size: 100%;
+}
 #top-bar {
     @fileFilterWidth: 300px;
     @barPadding: 0.2rem;


### PR DESCRIPTION
Normally, extension pages use the default serif fonts just like on normal web pages. Here is what it currently looks like on Chrome 36.0.1985.125:
![crx_viewer_-_google_chrome_2014-08-23_11-45-23](https://cloud.githubusercontent.com/assets/6135313/4019557/19c12a5e-2a78-11e4-88a1-d12b04ec14ea.png)

Now, extension pages have default operating-system-like styling that sets a default font-family and font-size.
https://codereview.chromium.org/400343002

On Chrome 39.0.2132.0 canary and 38.0.2125.8 dev-m, the default font-size is set to 75% on Windows and Mac OS (not sure about Linux or Chrome OS), which is a bit small.
![crx_viewer_-_google_chrome_2014-08-23_11-45-39](https://cloud.githubusercontent.com/assets/6135313/4019559/22f43490-2a78-11e4-9315-f6210ba33a30.png)

![crx](https://cloud.githubusercontent.com/assets/6135313/4019570/b1157270-2a78-11e4-888a-5c156d9047de.png)

This commit bumps the font-size back to 100%. Also, the font-family is set so that the current stable versions of Chrome can benefit from some aesthetic changes.
