### PR TITLE
Add support for Options V2

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,10 @@
         "128": "icons/128.png"
     },
     "options_page": "options.html",
+    "options_ui": {
+        "page": "options.html",
+        "chrome_style": true
+    },
     "permissions": [
         "tabs",
         "webNavigation",

--- a/src/options.html
+++ b/src/options.html
@@ -6,18 +6,15 @@
 <style>
 body {
     margin: 2em 3em;
-    font-family: Arial, sans-serif;
-    font-size: 1.3em;
 }
 label {
     display: block;
     margin: 1em 0;;
+    line-height: 150%;
 }
 footer {
     border-top: 1px solid #CCC;
     padding: 1rem 0;
-    
-    font-size: 1rem;
     text-align: center;
 }
 </style>
@@ -36,7 +33,7 @@ footer {
     Add a context menu option to Chrome / Opera 15 extension links.
 </label>
 <label>
-    <a href="crxviewer.html">Open Viewer</a> - select a CRX / NEX / ZIP file to view its contents.
+    <a href="crxviewer.html" target="_blank">Open Viewer</a> - select a CRX / NEX / ZIP file to view its contents.
 </label>
 <footer>
     &copy; 2013 - 2014 Rob Wu &lt;rob@robwu.nl&gt;


### PR DESCRIPTION
This PR add support for the new options page format described [here](https://developer.chrome.com/extensions/optionsV2). Since the modal options dialog should not be used as a generic view, the link to the extension viewer now opens in a new tab.