### PR TITLE
ignore node_modules and add missing dependency (shelljs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-src/*.css
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+src/*.css
+dist/

--- a/make.js
+++ b/make.js
@@ -24,7 +24,6 @@ function getBuildConfig(options) {
             OPERA: false
         },
         copy: [
-            [SRC_DIR + '*.css', dest_dir],
             [SRC_DIR + 'lib', dest_dir],
             [SRC_DIR + 'icons/*.png', dest_dir + 'icons']
         ],
@@ -49,9 +48,9 @@ function cleanDirectory(dir) {
 }
 
 function build(setup, output_root_dir) {
-    exec(ROOT_DIR + 'node_modules/.bin/lessc --strict-math=on "' + SRC_DIR + 'crxviewer.less" "' + SRC_DIR + 'crxviewer.css"');
     cleanDirectory(output_root_dir);
     builder.build(setup);
+    exec(ROOT_DIR + '/node_modules/.bin/lessc --strict-math=on "' + SRC_DIR + 'crxviewer.less" "' + output_root_dir + 'crxviewer.css"');
     cd(output_root_dir);
     rm('lib/beautify/jsbeautifier/get-jsb.sh');
     rm('lib/zip.js/VERSION');

--- a/make.js
+++ b/make.js
@@ -49,9 +49,9 @@ function cleanDirectory(dir) {
 }
 
 function build(setup, output_root_dir) {
+    exec(ROOT_DIR + 'node_modules/.bin/lessc --strict-math=on "' + SRC_DIR + 'crxviewer.less" "' + SRC_DIR + 'crxviewer.css"');
     cleanDirectory(output_root_dir);
     builder.build(setup);
-    exec(ROOT_DIR + '/node_modules/.bin/lessc --strict-math=on "' + SRC_DIR + 'crxviewer.less" "' + output_root_dir + 'crxviewer.css"');
     cd(output_root_dir);
     rm('lib/beautify/jsbeautifier/get-jsb.sh');
     rm('lib/zip.js/VERSION');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/Rob--W/crxviewer#readme",
   "private": true,
   "devDependencies": {
-    "less": "^2.5.1",
+    "less": "^2.7.1",
     "shelljs": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "private": true,
   "devDependencies": {
     "less": "^2.7.1",
-    "shelljs": "^0.7.0"
+    "shelljs": "0.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/Rob--W/crxviewer#readme",
   "private": true,
   "devDependencies": {
-    "less": "^2.5.1"
+    "less": "^2.5.1",
+    "shelljs": "^0.7.0"
   }
 }


### PR DESCRIPTION
And fix missing css in the src directory (needed by the `cp src/*.css` done while building).

I can only compile the web version, the chrome/opera version have this error.

```
Building Chrome extension...
/home/dam/yellow/repos/crxviewer/node_modules/shelljs/src/common.js:318
        throw e;
        ^

Error: cp: dest is not a directory (too many sources)
    at Object.error (/home/dam/yellow/repos/crxviewer/node_modules/shelljs/src/common.js:65:11)
    at _cp (/home/dam/yellow/repos/crxviewer/node_modules/shelljs/src/cp.js:202:12)
    at /home/dam/yellow/repos/crxviewer/node_modules/shelljs/src/common.js:303:25
    at /home/dam/yellow/repos/crxviewer/external/builder.js:178:5
    at Array.forEach (native)
    at Object.build (/home/dam/yellow/repos/crxviewer/external/builder.js:175:14)
    at build (/home/dam/yellow/repos/crxviewer/make.js:53:13)
    at Function.target.chrome (/home/dam/yellow/repos/crxviewer/make.js:78:5)
    at Object.global.target.(anonymous function) [as chrome] (/home/dam/yellow/repos/crxviewer/node_modules/shelljs/make.js:36:40)
    at Function.target.all (/home/dam/yellow/repos/crxviewer/make.js:61:12)
```