### PR TITLE
Add get_webstore_name

### DIFF
--- a/src/cws_pattern.js
+++ b/src/cws_pattern.js
@@ -151,6 +151,16 @@ function get_webstore_url(url) {
     }
 }
 
+// Get the name of the store for the url, returns: cws, ows, amo, undefined
+function get_webstore_name(url) {
+    var cws = cws_pattern.exec(url) || cws_download_pattern.exec(url);
+    if (cws) return 'cws';
+    var ows = ows_pattern.exec(url);
+    if (ows) return 'ows';
+    var amo = amo_pattern.exec(url) || amo_download_pattern.exec(url);
+    if (amo) return 'amo';
+}
+
 // Return the suggested name of the zip file.
 function get_zip_name(url, /*optional*/filename) {
     if (!filename) {


### PR DESCRIPTION
This file is so awesome. I'm remaking chrome store foxified and was using this and needed to know the name of the store. So added a function to get webstore name from url. We should add Edge support too! What's the name of their store? It seems to launch up the regular windows store app.

Maybe we should make a npm module out of this.