### PR TITLE
Add support for Thunderbird addons gallery

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -119,6 +119,8 @@ if (chrome.declarativeWebRequest) {
             hostEquals: 'addons.allizom.org'
         }, {
             hostEquals: 'addons-dev.allizom.org'
+        }, {
+            hostEquals: 'addons.thunderbird.net'
         }]
     };
     chrome.webNavigation.onCommitted.addListener(showPageActionIfNeeded, webNavigationFilter);

--- a/src/crxviewer.js
+++ b/src/crxviewer.js
@@ -1537,7 +1537,7 @@ function showAdvancedOpener() {
         var extensionId = get_extensionID(urlInput.value);
         var amoslug = get_amo_slug(urlInput.value);
         var maybeCrx = /\.crx([?#&]|$)|^(https?:\/\/)?(chrome|clients\d)\.google\.com/.test(urlInput.value) || !!extensionId;
-        var maybeXpi = /\.xpi([?#&]|$)|\.mozilla\./i.test(urlInput.value) || !!amoslug;
+        var maybeXpi = /\.xpi([?#&]|$)|\.mozilla\.|\.thunderbird\./i.test(urlInput.value) || !!amoslug;
         if (!extensionId) {
             cwsOptions.classList.add('disabled-site');
             if (maybeXpi) {

--- a/src/cws_pattern.js
+++ b/src/cws_pattern.js
@@ -24,10 +24,10 @@ var ows_pattern = /^https?:\/\/addons.opera.com\/.*?extensions\/(?:details|downl
 var ows_match_pattern = '*://addons.opera.com/*extensions/details/*';
 
 // Firefox addon gallery
-var amo_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org)\/.*?(?:addon|review)\/([^/<>"'?#]+)/;
-var amo_download_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org)\/[^?#]*\/downloads\/latest\/([^/?#]+)/;
-var amo_domain_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org)\//;
-var amo_file_version_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org)\/(?:[^?#\/]*\/)?firefox\/files\/browse\/(\d+)(\/[^?#\/]+\.xpi)?/;
+var amo_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org|addons\.thunderbird\.net)\/.*?(?:addon|review)\/([^/<>"'?#]+)/;
+var amo_download_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org|addons\.thunderbird\.net)\/[^?#]*\/downloads\/latest\/([^/?#]+)/;
+var amo_domain_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org|addons\.thunderbird\.net)\//;
+var amo_file_version_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org|addons\.thunderbird\.net)\/(?:[^?#\/]*\/)?(?:firefox|thunderbird)\/files\/browse\/(\d+)(\/[^?#\/]+\.xpi)?/;
 var amo_match_patterns = [
     '*://addons.mozilla.org/*addon/*',
     '*://addons.mozilla.org/*review/*',
@@ -35,11 +35,14 @@ var amo_match_patterns = [
     '*://addons.allizom.org/*review/*',
     '*://addons-dev.allizom.org/*addon/*',
     '*://addons-dev.allizom.org/*review/*',
+    '*://addons.thunderbird.net/*addon/*',
+    '*://addons.thunderbird.net/*review/*',
 ];
 var amo_file_version_match_patterns = [
     '*://addons.mozilla.org/*firefox/files/browse/*',
     '*://addons.allizom.org/*firefox/files/browse/*',
     '*://addons-dev.allizom.org/*firefox/files/browse/*',
+    '*://addons.thunderbird.net/*thunderbird/files/browse/*',
 ];
 
 // string extensionID if valid URL
@@ -70,7 +73,7 @@ function get_xpi_url(amoDomain, addonSlug) {
         platformId = 2;
     }
 
-    var url = 'https://' + amoDomain + '/firefox/downloads/latest/';
+    var url = get_amo_base_url(amoDomain) + '/downloads/latest/';
     url += addonSlug;
     url += '/platform:' + platformId;
     url += '/';
@@ -96,7 +99,7 @@ function get_crx_url(extensionID_or_url) {
     }
     match = amo_file_version_pattern.exec(extensionID_or_url);
     if (match) {
-        return 'https://' + match[1] + '/firefox/downloads/file/' + match[2] + (match[3] || '/addon.xpi');
+        return get_amo_base_url(match[1]) + '/downloads/file/' + match[2] + (match[3] || '/addon.xpi');
     }
     // Chrome Web Store
     match = get_extensionID(extensionID_or_url);
@@ -162,7 +165,7 @@ function get_webstore_url(url) {
     }
     var amo = get_amo_slug(url);
     if (amo) {
-        return 'https://' + get_amo_domain(url) + '/firefox/addon/' + amo;
+        return get_amo_base_url(get_amo_domain(url))+'/addon/' + amo;
     }
 }
 
@@ -180,6 +183,13 @@ function get_zip_name(url, /*optional*/filename) {
         }
     }
     return filename.replace(/\.(crx|jar|nex|xpi|zip)$/i, '') + '.zip';
+}
+
+function get_amo_base_url(amoDomain) {
+    if (amoDomain === 'addons.thunderbird.net') {
+        return 'https://addons.thunderbird.net/thunderbird';
+    }
+    return 'https://' + amoDomain + '/firefox';
 }
 
 function get_amo_domain(url) {


### PR DESCRIPTION
Hello @Rob--W 
Following your work on https://github.com/Rob--W/crxviewer/commit/ecbe019a990bcce7c7f54093befecd0a413fe16a for https://github.com/Rob--W/crxviewer/issues/72, this PR add pageAction support for the [Thunderbird addons gallery](https://addons.thunderbird.net).

Using the contextual menu already worked, but this seemed a +1 on usability to me.
Since https://github.com/thundernest/addons-server is a fork of the one used by Mozilla, I upgraded the amo regexes instead of adding new ones.

Also, it is present quite a bit of name hardcoding. I hope it's fine, considering I tryied to match what was already there.

Tested in Firefox 64.0 and Chrome 71.0.3578.98