### PR TITLE
Remove 7z dependency

### DIFF
--- a/make.js
+++ b/make.js
@@ -135,7 +135,7 @@ target.chrome = function() {
 
     cd(CHROME_BUILD_DIR);
     rm('-f', '../crxviewer.zip');
-    exec('7z a ../crxviewer.zip * -tzip');
+    exec('zip -r -q ../crxviewer.zip ./');
     lintDir(CHROME_BUILD_DIR);
 };
 
@@ -153,7 +153,7 @@ target.opera = function() {
 
     cd(OPERA_BUILD_DIR);
     rm('-f', '../crxviewer_opera.zip');
-    exec('7z a ../crxviewer_opera.zip * -tzip');
+    exec('zip -r -q ../crxviewer_opera.zip ./');
     lintDir(OPERA_BUILD_DIR);
 };
 
@@ -173,7 +173,7 @@ target.firefox = function() {
     // Split incognito is not supported in Firefox.
     rm('incognito-events.js');
     rm('-f', '../crxviewer_firefox.zip');
-    exec('7z a ../crxviewer_firefox.zip * -tzip');
+    exec('zip -r -q ../crxviewer_firefox.zip ./');
     lintDir(FIREFOX_BUILD_DIR);
 };
 


### PR DESCRIPTION
Unix systems come with `zip` by default, I believe. I don't think anything comes with `7z` installed. Instead of installing 7zip myself, I swapped my local install to these commands and had no problems. `-r` is for recursive, `-q` is to silence the output of "adding ..." for each file that is added.