### PR TITLE
Add support for the extensions in the Microsoft Edge Addons Store

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* globals chrome, cws_match_pattern, ows_match_pattern, amo_match_patterns,
+/* globals chrome, cws_match_pattern, mea_match_pattern, ows_match_pattern, amo_match_patterns,
    amo_file_version_match_patterns,
-   cws_pattern, ows_pattern, amo_pattern, amo_file_version_pattern,
+   cws_pattern, mea_pattern, ows_pattern, amo_pattern, amo_file_version_pattern,
    get_crx_url, get_zip_name, console,
     */
 /* globals encodeQueryString */
@@ -28,7 +28,7 @@ function togglePageAction(isEnabled) {
         browser.tabs.onUpdated.addListener(tabsOnUpdatedCheckPageAction);
     }
     browser.tabs.query({
-        url: [cws_match_pattern, ows_match_pattern].concat(amo_match_patterns, amo_file_version_match_patterns),
+        url: [cws_match_pattern, mea_match_pattern, ows_match_pattern].concat(amo_match_patterns, amo_file_version_match_patterns),
     }).then(function(tabs) {
         if (isEnabled) {
             tabs.forEach(showPageActionIfNeeded);
@@ -128,6 +128,7 @@ chrome.runtime.onInstalled.addListener(function() {
     chrome.tabs.query({
         url: [
             cws_match_pattern,
+            mea_match_pattern,
             ows_match_pattern,
         ].concat(amo_match_patterns, amo_file_version_match_patterns),
     }, function(tabs) {
@@ -226,6 +227,6 @@ function showPageActionIfNeeded(details_or_tab) {
     }
 }
 function isPageActionNeededForUrl(url) {
-    return cws_pattern.test(url) || ows_pattern.test(url) || amo_pattern.test(url) ||
-        amo_file_version_pattern.test(url);
+    return cws_pattern.test(url) || mea_pattern.test(url) || ows_pattern.test(url) ||
+        amo_pattern.test(url) || amo_file_version_pattern.test(url);
 }

--- a/src/bg-contextmenu.js
+++ b/src/bg-contextmenu.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* jshint browser:true, devel:true */
-/* globals chrome, cws_match_pattern, ows_match_pattern, amo_match_patterns, amo_file_version_match_patterns, get_crx_url */
+/* globals chrome, cws_match_pattern, mea_match_pattern, ows_match_pattern, amo_match_patterns, amo_file_version_match_patterns, get_crx_url */
 /* globals encodeQueryString */
 
 'use strict';
@@ -30,6 +30,7 @@
         '*://*/*.XPI*',
         '*://*/*.xpi*',
         cws_match_pattern,
+        mea_match_pattern,
         ows_match_pattern,
     ].concat(amo_file_version_match_patterns);
 
@@ -180,6 +181,7 @@
             contexts: ['all'],
             documentUrlPatterns: [
                 cws_match_pattern,
+                mea_match_pattern,
                 ows_match_pattern,
             ].concat(amo_file_version_match_patterns),
         });

--- a/src/crxviewer.html
+++ b/src/crxviewer.html
@@ -62,7 +62,7 @@ The filename filter is optional, '!search term' can also be used directly to sea
 <div id="advanced-open">
     <form id="advanced-open-form">
         Enter the URL of a Chrome Extension, Firefox addon, zip file,
-        or the page in the Chrome Web Store, Firefox addon gallery or Opera addon gallery.
+        or the page in the Chrome Web Store, Firefox addon gallery, Edge Addons Store or Opera addon gallery.
         <input type="url" placeholder="URL of Chrome extension, Firefox addon or zip file">
         <input type="submit" value="Open in this viewer">
         or select a local file &rarr;

--- a/src/crxviewer.js
+++ b/src/crxviewer.js
@@ -1574,7 +1574,7 @@ function initialize() {
     // the get_crx_url method only takes the extension ID and generates the other
     // parameters based on the current platform.
     if (!is_crx_download_url(crx_url)) {
-        if (cws_pattern.test(crx_url)) {
+        if (cws_pattern.test(crx_url) || mea_pattern.test(crx_url)) {
             // Prefer given URL because its slug contains an extra human-readable short name.
             webstore_url = crx_url;
         }


### PR DESCRIPTION
Created the patch to add support for the extensions in the Microsoft Edge Addons Store: https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home

Tested that with this change, the sources of extensions from both Chrome Webstore as well as Microsoft Edge Addons Store can be seen/downloaded and the corresponding CRX packages can also be downloaded.