### PR TITLE
Support Whale extensions store

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* globals navigator */
-/* globals chrome, cws_match_pattern, mea_match_pattern, ows_match_pattern, amo_match_patterns, atn_match_patterns,
+/* globals chrome, cws_match_pattern, mea_match_pattern, ows_match_pattern, wes_match_pattern, amo_match_patterns, atn_match_patterns,
    cws_pattern, mea_pattern, ows_pattern, amo_pattern, atn_pattern,
     */
 
@@ -56,7 +56,7 @@ function togglePageAction(isEnabled) {
         }
     }
     browser.tabs.query({
-        url: [cws_match_pattern, mea_match_pattern, ows_match_pattern].concat(amo_match_patterns, atn_match_patterns),
+        url: [cws_match_pattern, mea_match_pattern, ows_match_pattern, wes_match_pattern].concat(amo_match_patterns, atn_match_patterns),
     }).then(function(tabs) {
         tabs.forEach(showPageActionIfNeeded);
     });
@@ -102,7 +102,7 @@ function registerEventRules() {
         pathPrefix: "/webstore/detail/"
     }, {
         hostEquals: "microsoftedge.microsoft.com",
-        pathPrefix: "/webstore/detail/"
+        pathPrefix: "/addons/detail/"
     }, {
         hostEquals: "addons.opera.com",
         pathContains: "extensions/details/"
@@ -130,6 +130,9 @@ function registerEventRules() {
     }, {
         hostSuffix: "addons-stage.thunderbird.net",
         pathContains: "addon/"
+    }, {
+        hostSuffix: "store.whale.naver.com",
+        pathPrefix: "/detail/"
     }];
 
     var rule = {

--- a/src/cws_pattern.js
+++ b/src/cws_pattern.js
@@ -32,6 +32,11 @@ var ows_pattern = /^https?:\/\/addons.opera.com\/.*?extensions\/(?:details|downl
 var ows_download_pattern = /^https?:\/\/addons.opera.com\/extensions\/download\/([^\/]+)/;
 var ows_match_pattern = '*://addons.opera.com/*extensions/details/*';
 
+// Whale extensions store
+var wes_pattern = /^https?:\/\/store.whale.naver.com\/detail\/([a-z]{32})(?=[\/#?]|$)/;
+var wes_download_pattern = /^https?:\/\/store.whale.naver.com\/update\/whx\b.*?%3D([a-z]{32})%26/;
+var wes_match_pattern = '*://store.whale.naver.com\/detail/*';
+
 // Firefox addon gallery
 var amo_pattern = /^https?:\/\/((?:reviewers\.)?(?:addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org))\/.*?(?:addon|review)\/([^/<>"'?#]+)/;
 var amo_download_pattern = /^https?:\/\/(addons\.mozilla\.org|addons(?:-dev)?\.allizom\.org)\/[^?#]*\/downloads\/latest\/([^/?#]+)/;
@@ -125,6 +130,10 @@ function get_crx_url(extensionID_or_url) {
     if (match) {
         return 'https://edge.microsoft.com/extensionwebstorebase/v1/crx?response=redirect&x=id%3D' + match[1] + '%26installsource%3Dondemand%26uc';
     }
+    match = wes_pattern.exec(extensionID_or_url) || wes_download_pattern.exec(extensionID_or_url);
+    if (match) {
+        return 'https://store.whale.naver.com/update/whx?response=redirect&x=id%3D' + match[1] + '%26installsource%3Dondemand%26uc';
+    }
     // Chrome Web Store
     match = get_extensionID(extensionID_or_url);
     var extensionID = match ? match : extensionID_or_url;
@@ -191,6 +200,10 @@ function get_webstore_url(url) {
     var ows = ows_pattern.exec(url) || ows_download_pattern.exec(url);
     if (ows) {
         return 'https://addons.opera.com/extensions/details/' + ows[1];
+    }
+    var wes = wes_pattern.exec(url) || wes_download_pattern.exec(url);
+    if (wes) {
+        return 'https://store.whale.naver.com/detail/' + wes[1];
     }
     var amo = get_amo_slug(url);
     if (amo) {
@@ -291,6 +304,7 @@ function is_not_crx_url(url) {
         cws_pattern.test(url) || cws_download_pattern.test(url) ||
         mea_pattern.test(url) || mea_download_pattern.test(url) ||
         ows_pattern.test(url) || ows_download_pattern.test(url) ||
+        wes_pattern.test(url) || wes_download_pattern.test(url) ||
         /\.(crx|nex)\b/.test(url)
     ) {
         return false;
@@ -312,6 +326,7 @@ function is_crx_download_url(url) {
     return cws_download_pattern.test(url) ||
         mea_download_pattern.test(url) ||
         ows_download_pattern.test(url) ||
+        wes_download_pattern.test(url) ||
         amo_download_pattern.test(url) ||
         atn_download_pattern.test(url) ||
         /\.(crx|nex|xpi)\b/.test(url);
@@ -322,6 +337,7 @@ function is_webstore_url(url) {
     return cws_pattern.test(url) ||
         mea_pattern.test(url) ||
         ows_pattern.test(url) ||
+        wes_pattern.test(url) ||
         amo_pattern.test(url) ||
         atn_pattern.test(url);
 }


### PR DESCRIPTION
[Whale browser](https://whale.naver.com/en/) is based on Chromium, is run by [Naver](https://en.wikipedia.org/wiki/Naver_Corporation), and has a noticeable market share of [%6](https://gs.statcounter.com/browser-market-share/desktop/south-korea) in South Korea. Similar to Edge, it supports installing extensions from CWS but also from its own store https://store.whale.naver.com/extensions/. Would you consider adding support for this store in crxviewer? I tried to update references to regexes throughout the sources with appropriate regex for whale web store. Also I've fixed a match pattern that wasn't working for edge add-ons store.