### PR TITLE
fix: Support new CWS URL

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -101,6 +101,9 @@ function registerEventRules() {
         hostEquals: "chrome.google.com",
         pathPrefix: "/webstore/detail/"
     }, {
+        hostEquals: "chromewebstore.google.com",
+        pathPrefix: "/detail/"
+    }, {
         hostEquals: "microsoftedge.microsoft.com",
         pathPrefix: "/webstore/detail/"
     }, {

--- a/src/cws_pattern.js
+++ b/src/cws_pattern.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // cws_pattern[1] = extensionID
-var cws_pattern = /^https?:\/\/chrome.google.com\/webstore\/.+?\/([a-z]{32})(?=[\/#?]|$)/;
+var cws_pattern = /^https?:\/\/(?:chrome.google.com\/webstore|chromewebstore.google.com)\/.+?\/([a-z]{32})(?=[\/#?]|$)/;
 var cws_download_pattern = /^https?:\/\/clients2\.google\.com\/service\/update2\/crx\b.*?%3D([a-z]{32})%26uc/;
 // match pattern per Chrome spec
 var cws_match_pattern = '*://chrome.google.com/webstore/detail/*';

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -27,6 +27,7 @@
         "default_popup": "popup.html",
         "show_matches": [
             "*://chrome.google.com/webstore/detail/*",
+            "*://chromewebstore.google.com/detail/*",
             "*://microsoftedge.microsoft.com/addons/detail/*",
             "*://addons.opera.com/*extensions/details/*",
             "*://addons.mozilla.org/*addon/*",


### PR DESCRIPTION
Fixes #134 
Tested all changes in browser and web demo.

--

https://github.com/Rob--W/crxviewer/blob/e7ccd4f49d550e189e0d5a444790fffdc0065dc4/src/cws_pattern.js#L185
No change needed here. CWS automatically redirects you to new CWS, only if you actually enabled the new CWS. So the current link is more of a permalink and will probably not be deprecated soon.